### PR TITLE
ci(pi): kernai/refinery-parent-images:v2.2.0-torch-cpu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kernai/refinery-parent-images:v2.1.0-torch-cpu
+FROM kernai/refinery-parent-images:v2.2.0-torch-cpu
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y curl libgomp1 && \


### PR DESCRIPTION
Automated parent image release for:
- https://github.com/code-kern-ai/refinery-torch-cpu-parent-image/releases/tag/v2.2.0